### PR TITLE
Fix order creation time format

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -33,7 +33,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {`${createdDate.toLocaleTimeString('it-IT')}`}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">
@@ -47,6 +47,6 @@ class ViewOrders extends Component {
             </Template>
         );
     }
-}
+  }
 
 export default ViewOrders;


### PR DESCRIPTION
#### Fix for Order creation time format bug by using `toLocaleTimeString` built-in function.
fixes https://github.com/Shift3/react-challenge-project/issues/30