### PR TITLE
Fix: Order form submission bug

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
Fixed the incorrect state variable in `setState` in `FormOrder` component that caused the order submission bug.
fixes https://github.com/Shift3/react-challenge-project/issues/14